### PR TITLE
shap.KernelExplainer wrapper and ModelSurvSHAP interface changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def run_setup():
         maintainer="Mateusz Krzyziński",
         author="Mateusz Krzyziński",
         author_email="mateusz.krzyzinski.stud@pw.edu.pl",
-        version="0.2.1",
+        version="0.3.0",
         description="SurvSHAP(t): Time-dependent explanations of machine learning survival models",
         url="#",
         install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def run_setup():
         maintainer="Mateusz Krzyziński",
         author="Mateusz Krzyziński",
         author_email="mateusz.krzyzinski.stud@pw.edu.pl",
-        version="0.2.0",
+        version="0.2.1",
         description="SurvSHAP(t): Time-dependent explanations of machine learning survival models",
         url="#",
         install_requires=[

--- a/survshap/__init__.py
+++ b/survshap/__init__.py
@@ -2,7 +2,7 @@ from .predict_explanations.object import PredictSurvSHAP
 from .model_explanations.object import ModelSurvSHAP
 from .explainer import SurvivalModelExplainer
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 
 __all__ = [

--- a/survshap/__init__.py
+++ b/survshap/__init__.py
@@ -2,7 +2,7 @@ from .predict_explanations.object import PredictSurvSHAP
 from .model_explanations.object import ModelSurvSHAP
 from .explainer import SurvivalModelExplainer
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 
 __all__ = [

--- a/survshap/model_explanations/object.py
+++ b/survshap/model_explanations/object.py
@@ -57,7 +57,7 @@ class ModelSurvSHAP:
         # based on original shap warning
         data_len = len(explainer.data)
         if data_len > 100:
-            warnings.warn("Using " + data_len + " background data samples could cause slower run times.\n" +
+            warnings.warn("Using " + str(data_len) + " background data samples could cause slower run times.\n" +
                           "Consider using a smaller sample.")
             
         if new_observations is None: 

--- a/survshap/model_explanations/object.py
+++ b/survshap/model_explanations/object.py
@@ -23,7 +23,7 @@ class ModelSurvSHAP:
         
         Args:
             function_type (str, optional): Either "sf" representing survival function or "chf" representing cumulative hazard function. Type of function to be evaluated for explanation. Defaults to "sf".
-            calculation_method (str, optional): Either "kernel" for kernelSHAP or "sampling" for sampling method. Chooses type of survSHAP calculation . Defaults to "kernel".
+            calculation_method (str, optional): Chooses type of survSHAP calculation. "shap" for shap.KernelExplainer, "kernel" for exact KernelSHAP, or "sampling" for sampling method. Defaults to "kernel".
             aggregation_method (str, optional): One of "sum_of_squares", "max_abs", "mean_abs" or "integral". Type of method  Defaults to "integral".
             path (list of int or str, optional): If specified, then attributions for this path will be plotted. Defaults to "average".
             B (int, optional): Number of random paths to calculate variable attributions. Defaults to 25.
@@ -45,7 +45,7 @@ class ModelSurvSHAP:
     def _repr_html_(self):
         return self.result[self.result["B"] == 0]._repr_html_()
      
-    def fit(self, explainer, new_observations=None, timestamps=None, save_individual_explanations=True):
+    def fit(self, explainer, new_observations=None, timestamps=None, save_individual_explanations=True, **kwargs):
         """Calculate SurvSHAP(t) for many new observations and aggregate results.
 
         Args:
@@ -53,11 +53,12 @@ class ModelSurvSHAP:
             new_observations (pandas.DataFrame, optional): A DataFrame containing the observations to be explained. If None observations from explainer are explained. Defaults to None. 
             timestamps (numpy.Array, optional): An array of timestamps at which SurvSHAP(t) values should be calculated. Defaults to None.
             save_individual_explanations (bool, optional): Whether to save PredictSurvSHAP objects (explanations for individual observations). Defaults to True.
+            **kwargs (optional): Additional parameters passed for shap.KernelExplainer. 
         """
         # based on original shap warning
         data_len = len(explainer.data)
-        if data_len > 100:
-            warnings.warn("Using " + data_len + " background data samples could cause slower run times.\n" +
+        if data_len > 100 and self.calculation_method != "shap":
+            warnings.warn("Using " + str(data_len) + " background data samples could cause slower run times.\n" +
                           "Consider using a smaller sample.")
             
         if new_observations is None: 
@@ -78,6 +79,7 @@ class ModelSurvSHAP:
             self.aggregation_method,
             timestamps,
             save_individual_explanations,
+            **kwargs
         )
 
         names = explainer.y.dtype.names

--- a/survshap/model_explanations/object.py
+++ b/survshap/model_explanations/object.py
@@ -7,7 +7,7 @@ import pandas as pd
 import numpy as np
 import pandas as pd
 from .utils import aggregate_change, calculate_individual_explanations
-
+import warnings
 
 class ModelSurvSHAP:
     def __init__(
@@ -19,6 +19,16 @@ class ModelSurvSHAP:
         B=25,
         random_state=None,
     ):
+        """Constructor for class ModelSurvSHAP
+        
+        Args:
+            function_type (str, optional): Either "sf" representing survival function or "chf" representing cumulative hazard function. Type of function to be evaluated for explanation. Defaults to "sf".
+            calculation_method (str, optional): Either "kernel" for kernelSHAP or "sampling" for sampling method. Chooses type of survSHAP calculation . Defaults to "kernel".
+            aggregation_method (str, optional): One of "sum_of_squares", "max_abs", "mean_abs" or "integral". Type of method  Defaults to "integral".
+            path (list of int or str, optional): If specified, then attributions for this path will be plotted. Defaults to "average".
+            B (int, optional): Number of random paths to calculate variable attributions. Defaults to 25.
+            random_state (int, optional): Set seed for random number generator. Defaults to None.
+        """
         self.explainer = None
         self.function_type = function_type
         self.calculation_method = calculation_method
@@ -34,14 +44,32 @@ class ModelSurvSHAP:
 
     def _repr_html_(self):
         return self.result[self.result["B"] == 0]._repr_html_()
+     
+    def fit(self, explainer, new_observations=None, timestamps=None, save_individual_explanations=True):
+        """Calculate SurvSHAP(t) for many new observations and aggregate results.
 
-    def fit(self, explainer, timestamps=None, save_individual_explanations=True):
+        Args:
+            explainer (SurvivalModelExplainer): A wrapper object for the model to be explained.
+            new_observations (pandas.DataFrame, optional): A DataFrame containing the observations to be explained. If None observations from explainer are explained. Defaults to None. 
+            timestamps (numpy.Array, optional): An array of timestamps at which SurvSHAP(t) values should be calculated. Defaults to None.
+            save_individual_explanations (bool, optional): Whether to save PredictSurvSHAP objects (explanations for individual observations). Defaults to True.
+        """
+        # based on original shap warning
+        data_len = len(explainer.data)
+        if data_len > 100:
+            warnings.warn("Using " + data_len + " background data samples could cause slower run times.\n" +
+                          "Consider using a smaller sample.")
+            
+        if new_observations is None: 
+            new_observations = explainer.data
+
         (
             self.full_result,
             self.individual_explanations,
             self.timestamps,
         ) = calculate_individual_explanations(
             explainer,
+            new_observations,
             self.function_type,
             self.path,
             self.B,

--- a/survshap/model_explanations/utils.py
+++ b/survshap/model_explanations/utils.py
@@ -11,6 +11,7 @@ from scipy.integrate import trapezoid
 
 def calculate_individual_explanations(
     explainer,
+    new_observations,
     function_type,
     path,
     B,
@@ -31,11 +32,7 @@ def calculate_individual_explanations(
             aggregation_method=aggregation_method,
             random_state=random_state,
         )
-        if explainer.y is not None:
-            y_true_i = explainer.y[i]
-        else:
-            y_true_i = None
-        survSHAP_obj.fit(explainer, explainer.data.iloc[[i]], timestamps, y_true_i)
+        survSHAP_obj.fit(explainer, new_observations.iloc[[i]], timestamps)
         if save_individual_explanations:
             individual_explanations.append(survSHAP_obj)
         tmp_results = survSHAP_obj.result

--- a/survshap/model_explanations/utils.py
+++ b/survshap/model_explanations/utils.py
@@ -2,11 +2,15 @@ from copy import deepcopy
 from dataclasses import dataclass
 import numpy as np
 import pandas as pd
+
+from survshap.predict_explanations.utils import prepare_result_df
 from ..predict_explanations.object import PredictSurvSHAP
 from tqdm import tqdm
 import matplotlib.pyplot as plt
 from statsmodels.graphics.functional import fboxplot
 from scipy.integrate import trapezoid
+import shap
+import warnings
 
 
 def calculate_individual_explanations(
@@ -20,24 +24,70 @@ def calculate_individual_explanations(
     aggregation_method,
     timestamps,
     save_individual_explanations,
+    **kwargs
 ):
     individual_explanations = []
     concatenated_results = pd.DataFrame()
-    for i in tqdm(range(len(explainer.data))):
-        survSHAP_obj = PredictSurvSHAP(
-            function_type=function_type,
-            path=path,
-            B=B,
-            calculation_method=calculation_method,
-            aggregation_method=aggregation_method,
-            random_state=random_state,
-        )
-        survSHAP_obj.fit(explainer, new_observations.iloc[[i]], timestamps)
-        if save_individual_explanations:
-            individual_explanations.append(survSHAP_obj)
-        tmp_results = survSHAP_obj.result
-        tmp_results.insert(5, "index", i)
-        concatenated_results = pd.concat((concatenated_results, tmp_results), axis=0)
+    
+    preds = explainer.predict(explainer.data, function_type)
+    if timestamps is None:
+        timestamps = preds[0].x
+        preds = [f.y for f in preds]
+    else:
+        preds = [f(timestamps) for f in preds]
+    baseline_f = np.mean(preds, axis=0)
+
+
+    if calculation_method == "shap":
+        def predict_function(X):
+            all_functions = explainer.predict(X, function_type)
+            preds = np.array([f(timestamps) for f in all_functions])
+            return preds
+
+        # as shap convert pd.DataFrame to np.array 
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            exp = shap.KernelExplainer(predict_function, explainer.data, **kwargs)
+            res = exp.shap_values(new_observations)
+        tmp = np.dstack(res).flatten()
+        new_observations_shape = new_observations.shape
+        tmp = tmp.reshape(new_observations_shape[0] * new_observations_shape[1], len(timestamps))
+        variable_names = explainer.data.columns
+
+        for i in range(new_observations_shape[0]):
+            survSHAP_obj = PredictSurvSHAP(
+                function_type=function_type,
+                calculation_method=calculation_method,
+                aggregation_method=aggregation_method,
+                random_state=random_state,
+            )
+            survSHAP_obj.result = prepare_result_df(new_observations.iloc[[i]], variable_names, 
+                                                    tmp[(new_observations_shape[1]*i):(new_observations_shape[1]*(i+1)), :],
+                                                    timestamps, aggregation_method)
+            survSHAP_obj.predicted_function = explainer.predict(new_observations, function_type)[0](timestamps)
+            survSHAP_obj.baseline_function = baseline_f
+            survSHAP_obj.timestamps = timestamps
+            if save_individual_explanations:
+                individual_explanations.append(survSHAP_obj)
+            tmp_results = survSHAP_obj.result
+            tmp_results.insert(5, "index", i)
+            concatenated_results = pd.concat((concatenated_results, tmp_results), axis=0)
+    else:
+        for i in tqdm(range(len(new_observations))):
+            survSHAP_obj = PredictSurvSHAP(
+                function_type=function_type,
+                path=path,
+                B=B,
+                calculation_method=calculation_method,
+                aggregation_method=aggregation_method,
+                random_state=random_state,
+            )
+            survSHAP_obj.fit(explainer, new_observations.iloc[[i]], timestamps)
+            if save_individual_explanations:
+                individual_explanations.append(survSHAP_obj)
+            tmp_results = survSHAP_obj.result
+            tmp_results.insert(5, "index", i)
+            concatenated_results = pd.concat((concatenated_results, tmp_results), axis=0)
     if timestamps is None:
         timestamps = survSHAP_obj.timestamps
     return concatenated_results, individual_explanations, timestamps

--- a/survshap/model_explanations/utils.py
+++ b/survshap/model_explanations/utils.py
@@ -23,7 +23,7 @@ def calculate_individual_explanations(
 ):
     individual_explanations = []
     concatenated_results = pd.DataFrame()
-    for i in tqdm(range(len(explainer.data))):
+    for i in tqdm(range(len(new_observations))):
         survSHAP_obj = PredictSurvSHAP(
             function_type=function_type,
             path=path,

--- a/survshap/predict_explanations/object.py
+++ b/survshap/predict_explanations/object.py
@@ -2,14 +2,14 @@ from .plot import predict_plot
 import pandas as pd
 import numpy as np
 import pandas as pd
-from .utils import check_new_observation, shap_kernel, shap_sampling
+from .utils import check_new_observation, shap_kernel, shap_sampling, shap_kernel_explainer
 
 
 class PredictSurvSHAP:
     def __init__(
         self,
         function_type="sf",
-        calculation_method="kernel",
+        calculation_method="shap",
         aggregation_method="integral",
         path="average",
         B=25,
@@ -20,7 +20,7 @@ class PredictSurvSHAP:
 
         Args:
             function_type (str, optional): Either "sf" representing survival function or "chf" representing cumulative hazard function. Type of function to be evaluated for explanation. Defaults to "sf".
-            calculation_method (str, optional): Either "kernel" for kernelSHAP or "sampling" for sampling method. Chooses type of survSHAP calculation . Defaults to "kernel".
+            calculation_method (str, optional): "shap" for KernelExplainer from SHAP library, "kernel" for exact KernelSHAP or "sampling" for sampling method. Chooses type of survSHAP calculation . Defaults to "shap".
             aggregation_method (str, optional): One of "sum_of_squares", "max_abs", "mean_abs" or "integral". Type of method  Defaults to "integral".
             path (list of int or str, optional): If specified, then attributions for this path will be plotted. Defaults to "average".
             B (int, optional): Number of random paths to calculate variable attributions. Defaults to 25.
@@ -98,6 +98,20 @@ class PredictSurvSHAP:
                 self.aggregation_method,
                 timestamps,
                 self.exact,
+            )
+        elif self.calculation_method == "shap":
+            (
+                self.result,
+                self.predicted_function,
+                self.baseline_function,
+                self.timestamps,
+            ) = shap_kernel_explainer(
+                explainer,
+                new_observation,
+                self.function,
+                self.random_state,
+                self.aggregation_method,
+                timestamps,
             )
         else:
             raise ValueError("calculation_method should be 'kernel' or 'sampling'")

--- a/survshap/predict_explanations/object.py
+++ b/survshap/predict_explanations/object.py
@@ -9,7 +9,7 @@ class PredictSurvSHAP:
     def __init__(
         self,
         function_type="sf",
-        calculation_method="shap",
+        calculation_method="kernel",
         aggregation_method="integral",
         path="average",
         B=25,
@@ -20,7 +20,7 @@ class PredictSurvSHAP:
 
         Args:
             function_type (str, optional): Either "sf" representing survival function or "chf" representing cumulative hazard function. Type of function to be evaluated for explanation. Defaults to "sf".
-            calculation_method (str, optional): "shap" for KernelExplainer from SHAP library, "kernel" for exact KernelSHAP or "sampling" for sampling method. Chooses type of survSHAP calculation . Defaults to "shap".
+            calculation_method (str, optional): Chooses type of survSHAP calculation. "shap" for shap.KernelExplainer, "kernel" for exact KernelSHAP, or "sampling" for sampling method. Defaults to "kernel".
             aggregation_method (str, optional): One of "sum_of_squares", "max_abs", "mean_abs" or "integral". Type of method  Defaults to "integral".
             path (list of int or str, optional): If specified, then attributions for this path will be plotted. Defaults to "average".
             B (int, optional): Number of random paths to calculate variable attributions. Defaults to 25.
@@ -109,7 +109,6 @@ class PredictSurvSHAP:
                 explainer,
                 new_observation,
                 self.function,
-                self.random_state,
                 self.aggregation_method,
                 timestamps,
             )

--- a/survshap/predict_explanations/utils.py
+++ b/survshap/predict_explanations/utils.py
@@ -33,12 +33,12 @@ def shap_kernel_explainer(explainer,
         preds = np.array([f(timestamps) for f in all_functions])
         return preds
 
-    exp = shap.KernelExplainer(predict_function, explainer.data)
-
     # as shap convert pd.DataFrame to np.array 
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=UserWarning)
+        warnings.simplefilter("ignore", category=UserWarning)
+        exp = shap.KernelExplainer(predict_function, explainer.data)
         res = exp.shap_values(new_observation)
+        
     shap_values = np.vstack(res).T
     result_shap = pd.DataFrame(
         shap_values, columns=[" = ".join(["t", str(time)]) for time in timestamps]

--- a/survshap/predict_explanations/utils.py
+++ b/survshap/predict_explanations/utils.py
@@ -6,6 +6,64 @@ from tqdm import tqdm
 import math
 from scipy.integrate import trapezoid
 from sklearn.metrics import r2_score
+import shap
+import warnings
+
+def shap_kernel_explainer(explainer,
+                new_observation,
+                function_type,
+                random_state,
+                aggregation_method,
+                timestamps):
+    
+    target_fun = explainer.predict(new_observation, function_type)[0] 
+    all_functions = explainer.predict(explainer.data, function_type)
+
+    if timestamps is None:
+        target_fun = target_fun.y
+        all_functions_vals = [f.y for f in all_functions]
+        timestamps = all_functions[0].x
+    else:
+        target_fun = target_fun(timestamps)
+        all_functions_vals = [f(timestamps) for f in all_functions]
+    baseline_fun = np.mean(all_functions_vals, axis=0)
+
+    def predict_function(X):
+        all_functions = explainer.predict(X, function_type)
+        preds = np.array([f(timestamps) for f in all_functions])
+        return preds
+
+    exp = shap.KernelExplainer(predict_function, explainer.data)
+
+    # as shap convert pd.DataFrame to np.array 
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning)
+        res = exp.shap_values(new_observation)
+    shap_values = np.vstack(res).T
+    result_shap = pd.DataFrame(
+        shap_values, columns=[" = ".join(["t", str(time)]) for time in timestamps]
+    )
+
+    variable_names = explainer.data.columns
+    new_observation_f = new_observation.apply(lambda x: nice_format(x.iloc[0]))
+    result_meta = pd.DataFrame(
+        {
+            "variable_str": [
+                " = ".join(pair) for pair in zip(variable_names, new_observation_f)
+            ],
+            "variable_name": variable_names,
+            "variable_value": new_observation.values.reshape(
+                -1,
+            ),
+            "B": 0,
+            "aggregated_change": aggregate_change(
+                result_shap, aggregation_method, timestamps
+            ),
+        }
+    )
+
+    result = pd.concat([result_meta, result_shap], axis=1)
+    return result, target_fun, baseline_fun, timestamps
 
 
 def shap_kernel(


### PR DESCRIPTION
**Changes:** 
-  Separating background dataset from data to explain in ModelSurvSHAP (new optional parameter `new_observations`). 
- Added wrapper for `shap.KernelExplainer` for both local and global explanations. 


**NOTE:**  for tested examples our internal KernelSHAP implementation is faster than using `shap.KernelExplainer` but it was worth a try 