### PR TITLE
Approximate Survival Shapley

### DIFF
--- a/survshap/model_explanations/object.py
+++ b/survshap/model_explanations/object.py
@@ -18,6 +18,7 @@ class ModelSurvSHAP:
         path="average",
         B=25,
         random_state=None,
+        max_shap_value_inputs=np.inf
     ):
         self.explainer = None
         self.function_type = function_type
@@ -31,6 +32,7 @@ class ModelSurvSHAP:
         self.event_ind = None  # full y
         self.event_times = None  # full y
         self.full_result = None
+        self.max_shap_value_inputs = max_shap_value_inputs
 
     def _repr_html_(self):
         return self.result[self.result["B"] == 0]._repr_html_()
@@ -50,6 +52,7 @@ class ModelSurvSHAP:
             self.aggregation_method,
             timestamps,
             save_individual_explanations,
+            self.max_shap_value_inputs,
         )
 
         names = explainer.y.dtype.names

--- a/survshap/model_explanations/utils.py
+++ b/survshap/model_explanations/utils.py
@@ -19,6 +19,7 @@ def calculate_individual_explanations(
     aggregation_method,
     timestamps,
     save_individual_explanations,
+    max_shap_value_inputs=np.inf
 ):
     individual_explanations = []
     concatenated_results = pd.DataFrame()
@@ -30,6 +31,7 @@ def calculate_individual_explanations(
             calculation_method=calculation_method,
             aggregation_method=aggregation_method,
             random_state=random_state,
+            max_shap_value_inputs=max_shap_value_inputs
         )
         if explainer.y is not None:
             y_true_i = explainer.y[i]

--- a/survshap/predict_explanations/object.py
+++ b/survshap/predict_explanations/object.py
@@ -15,6 +15,7 @@ class PredictSurvSHAP:
         B=25,
         random_state=None,
         exact=False,
+        max_shap_value_inputs=np.inf
     ):
         """Constructor for class PredictSurvSHAP
 
@@ -44,6 +45,7 @@ class PredictSurvSHAP:
         self.y_true_time = None  # for this instance
         self.y_true_ind = None  # for this instance
         self.r2 = None
+        self.max_shap_value_inputs = max_shap_value_inputs
 
     def _repr_html_(self):
         return self.simplified_result._repr_html_()
@@ -81,6 +83,7 @@ class PredictSurvSHAP:
                 self.function,
                 self.aggregation_method,
                 timestamps,
+                self.max_shap_value_inputs
             )
         elif self.calculation_method == "sampling":
             (

--- a/survshap/predict_explanations/utils.py
+++ b/survshap/predict_explanations/utils.py
@@ -9,7 +9,7 @@ from sklearn.metrics import r2_score
 
 
 def shap_kernel(
-    explainer, new_observation, function_type, aggregation_method, timestamps
+    explainer, new_observation, function_type, aggregation_method, timestamps, max_shap_value_inputs=np.inf
 ):
     p = new_observation.shape[1]
 
@@ -26,7 +26,12 @@ def shap_kernel(
         all_functions_vals = [f(timestamps) for f in all_functions]
     baseline_f = np.mean(all_functions_vals, axis=0)
 
-    simplified_inputs = [list(z) for z in itertools.product(range(2), repeat=p)]
+    if 2**p<max_shap_value_inputs:
+        simplified_inputs = [list(z) for z in itertools.product(range(2), repeat=p)]
+    else:
+        simplified_inputs = list(np.random.randint(0,2,size=(max_shap_value_inputs,p)))
+        print(f"Approximate Survival Shapley will sample only {max_shap_value_inputs} values instead of 2**{p} for Exact Shapley")
+
     kernel_weights = generate_shap_kernel_weights(simplified_inputs, p)
     shap_values, r2 = calculate_shap_values(
         explainer,


### PR DESCRIPTION
```
import numpy as np
import pandas as pd
from survshap import SurvivalModelExplainer, ModelSurvSHAP
import time

np.random.seed(42)
nb_features=8
nb_events=150

np_X=np.random.rand(nb_events, nb_features)
np_time=np.random.rand(nb_events, 1)
np_is_living=np_X[:,0] < np_time[:,0]

y=np.empty(nb_events, dtype=[('event', '?'), ('time', '<f16')])
y['event']=np_is_living.reshape(-1)
y['time']=np_time.reshape(-1)
X=pd.DataFrame(np_X,columns=['f'+str(i) for i in range(1,nb_features+1)])

from sksurv.ensemble import RandomSurvivalForest
rsf=RandomSurvivalForest(random_state=42)
st=time.time()
rsf.fit(X,y)
print(f"score:{rsf.score(X,y)} fit time:{time.time()-st}")
print(f"predict: {rsf.predict(X)}")


exp_rsf=SurvivalModelExplainer(rsf,X,y)
ms_rsf=ModelSurvSHAP(random_state=42)                         # <-------- EXACT SURVIVAL SHAP
#ms_rsf=ModelSurvSHAP(random_state=42,max_shap_value_inputs=20) # <-------- APPROXIMATE SURVIVAL SHAP
st=time.time()
ms_rsf.fit(exp_rsf)
print(f"Interpretation time:{time.time()-st}")

# The scope of these changes made to
# pandas settings are local to with statement.
with pd.option_context('display.max_rows', None,
                       'display.max_columns', None,
                       'display.precision', 3,
                       ):
    ms_rsf.get_mean_abs_shap_values()
    print(ms_rsf.result)
```


OUTPUT:


THE EXACT VERSION TAKES 363 seconds:

100%|██████████| 150/150 [06:03<00:00,  2.42s/it]
Interpretation time:363.3058955669403
  variable_name  variable_value    B  aggregated_change  index  \
0            f1           0.466  0.0              0.901   74.5   
2            f3           0.455  0.0              0.105   74.5   
6            f7           0.501  0.0              0.094   74.5   
5            f6           0.508  0.0              0.056   74.5   
3            f4           0.544  0.0              0.051   74.5   
4            f5           0.509  0.0              0.036   74.5   
7            f8           0.509  0.0              0.035   74.5   
1            f2           0.502  0.0              0.027   74.5   
 

THE APPROXIMATE VERSION TAKES 32 seconds:

100%|██████████| 150/150 [00:31<00:00,  4.70it/s]
Interpretation time:32.05052995681763
  variable_name  variable_value    B  aggregated_change  index  \
0            f1           0.466  0.0              0.891   74.5   
2            f3           0.455  0.0              0.102   74.5   
6            f7           0.501  0.0              0.086   74.5   
5            f6           0.508  0.0              0.055   74.5   
3            f4           0.544  0.0              0.050   74.5   
4            f5           0.509  0.0              0.034   74.5   
7            f8           0.509  0.0              0.033   74.5   
1            f2           0.502  0.0              0.026   74.5   


CONCLUSION MUCH FASTER, MUCH MEMORY EFFICIENT AND ABOUT THE SAME RESULT